### PR TITLE
Use SVG badge instead of PNG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Uppercase the first character of a string
 
-[![Build Status](https://travis-ci.org/deathcap/ucfirst.png)](https://travis-ci.org/deathcap/ucfirst)
+[![Build Status](https://travis-ci.org/deathcap/ucfirst.svg?branch=master)](https://travis-ci.org/deathcap/ucfirst)
 
     var ucfirst = require('ucfirst');
 
@@ -11,5 +11,3 @@ Uppercase the first character of a string
 ## License
 
 MIT
-
-


### PR DESCRIPTION
SVG badges look beautiful on retina displays.

| before | after |
| --- | --- |
| [![Build Status](https://travis-ci.org/deathcap/ucfirst.png?branch=master)](https://travis-ci.org/deathcap/ucfirst) | [![Build Status](https://travis-ci.org/deathcap/ucfirst.svg?branch=master)](https://travis-ci.org/deathcap/ucfirst) |
