### PR TITLE
Fixed so that only strings will use this function

### DIFF
--- a/ucfirst.js
+++ b/ucfirst.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = function ucfirst(s) {
-  return s.charAt(0).toUpperCase() + s.substr(1);
+  return typeof s === 'string' ? s.charAt(0).toUpperCase() + s.substr(1) : s;
 };


### PR DESCRIPTION
Before the following resulted into an error:
```
ucfirst(null);
```
this should fix that, now only the function will work if it receives a `string` (not a `String` (object)) otherwise it returns the parameter `v`.